### PR TITLE
Fixed get_playlist is limited to 100 videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build/
 docs/source/_build
 .tox
 .env
+.DS_store


### PR DESCRIPTION
The error occurred because the playlists contained two `continuationEndpoint` elements.
- One for the video list.
- The second one is for recommended videos.

`get_next_data` always selects the last one, so it tried to get videos from recommended ones, not from a playlist.

So i added a parent selector, to select list of videos first and then select individual videos and appropriate continuation item.

Tested for channels and search as well.

Issues: #55, #45
